### PR TITLE
Remove workaround for torch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,6 @@ bash ./docker/init.sh
 docker-compose exec web fab run
 ```
 
-In both cases, the step of `db.populate_colors_in_db()` is fairly
-time-consuming.
-
-Note that `pip-compile` can't handle the version of `torch` we need
-here, so both the local instructions and the Docker init script
-include a manual upgrade. This should be fixed, and this note removed,
-in a future release.
+In both cases, the step of `db.populate_colors_in_db()` is
+time-consuming, presently about thirteen minutes on a 3.1 GHz
+quad-core Intel Core i7.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     build:
       context: .
       dockerfile: ./docker/Dockerfile
-    image: colors:0.02
+    image: colors:0.03
     tty: true
     command: bash
     environment:

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -2,15 +2,13 @@
 
 docker-compose up -d
 
+# make sure the database server is ready
 sleep 5
 
 docker-compose exec db createdb colors --user postgres
 
-# this is a bad workaround for inability to specify this version
-# in requirements.in
-docker-compose exec web pip install torch==0.4.1.post2
-
-# the last step here takes quite a lot of time
+# the last step here takes about thirteen minutes on
+# a 3.1 GHz quad-core Intel Core i7
 docker-compose exec web python -c "\
 from scripts import db ;\
 db.init_db() ;\

--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,7 @@ gunicorn
 
 -e git+git://github.com/anastasia/namecolor.git@aa2a8d7#egg=namecolor
 numpy==1.15.0       # required by namecolor, sensitive to version
+torch==0.4.1.post2  # required by namecolor, sensitive to version
 
 # tasks
 fabric3

--- a/requirements.txt
+++ b/requirements.txt
@@ -82,7 +82,7 @@ sqlalchemy==1.3.3
 terminado==0.8.1          # via notebook
 testpath==0.4.2           # via nbconvert
 toolz==0.9.0              # via dask
-torch==0.4.1
+torch==0.4.1.post2
 tornado==5.1.1            # via ipykernel, jupyter-client, notebook, terminado
 tqdm==4.51.0
 traitlets==4.3.2          # via ipykernel, ipython, ipywidgets, jupyter-client, jupyter-core, nbconvert, nbformat, notebook, qtconsole


### PR DESCRIPTION
I can't explain why `pip-compile` works now, unless the version were missing before and was replaced.